### PR TITLE
Italicize missed book titles in the endnotes

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -10,7 +10,7 @@
 			<h2 epub:type="title">Endnotes</h2>
 			<ol>
 				<li id="note-1" epub:type="endnote">
-					<p>This title amongst the Muhammadans comprehends the concrete character of prophet, priest, and king; and is used to signify “the Vicar of God on earth.” <cite>—⁠Habesci’s State of the Ottoman Empire, <abbr>p.</abbr> 9. Herbelot, <abbr>p.</abbr> 985</cite> <a href="vathek.xhtml#noteref-1" epub:type="backlink">↩</a></p>
+					<p>This title amongst the Muhammadans comprehends the concrete character of prophet, priest, and king; and is used to signify “the Vicar of God on earth.” <cite>—⁠Habesci’s <i epub:type="se:name.publication.book">State of the Ottoman Empire</i>, <abbr>p.</abbr> 9. Herbelot, <abbr>p.</abbr> 985</cite> <a href="vathek.xhtml#noteref-1" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-2" epub:type="endnote">
 					<p>The author of Nighiaristan hath preserved a fact that supports this account; and there is no history of Vathek, in which his “terrible eye” is not mentioned. <a href="vathek.xhtml#noteref-2" epub:type="backlink">↩</a></p>
@@ -31,7 +31,7 @@
 					<p>Dives of this kind are frequently mentioned by Eastern writers. Consult their tales in general, and especially those of “The Fisherman,” “Aladdin,” and “The Princess of China.” <a href="vathek.xhtml#noteref-7" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-8" epub:type="endnote">
-					<p>As it was the employment of the black eunuchs to wait upon, and guard the sultanas, to the general superintendence of the Harem was particularly committed to their chief. <cite>—⁠Habesci’s State of the Ottoman Empire, <abbr>p.</abbr> 155⁠–⁠6</cite> <a href="vathek.xhtml#noteref-8" epub:type="backlink">↩</a></p>
+					<p>As it was the employment of the black eunuchs to wait upon, and guard the sultanas, to the general superintendence of the Harem was particularly committed to their chief. <cite>—⁠Habesci’s <i epub:type="se:name.publication.book">State of the Ottoman Empire</i>, <abbr>p.</abbr> 155⁠–⁠6</cite> <a href="vathek.xhtml#noteref-8" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-9" epub:type="endnote">
 					<p>This was both the supreme council, and court of justice, at which the Caliphs of the race of the Abassides assisted in person to redress the injuries of every appellant. <cite>—⁠Herbelot, <abbr>p.</abbr> 298</cite> <a href="vathek.xhtml#noteref-9" epub:type="backlink">↩</a></p>


### PR DESCRIPTION
There were two instances in the endnotes of book titles missing italics. This commit/PR italicizes them and adds the appropriate semantic inflection in each case.